### PR TITLE
Melhorias no quadro

### DIFF
--- a/bilhetinhos/src/main/api/notifications.js
+++ b/bilhetinhos/src/main/api/notifications.js
@@ -33,7 +33,10 @@ const removeUserNotifications = async (uid, receivedDates) => {
             let returnCondition = receivedDates.includes(`${notif.receivedDate}`)
             return !returnCondition
         })
-        await getNotificationsRef().child(uid).set(notifications)
+        await getNotificationsRef().child(uid).set(notifications, () => {
+            if (window.location.pathname === '/mates/noteboard')
+                window.location = '/'
+        })
     }
 }
 

--- a/bilhetinhos/src/main/components/base/Accordion.jsx
+++ b/bilhetinhos/src/main/components/base/Accordion.jsx
@@ -20,7 +20,7 @@ const AccordionItem = props => {
                     </button>
                 </h2>
             </div>
-            <div id={`collapse-${props.itemId}`} className={`collapse ${props.open ? 'show' : ''}`} aria-labelledby={`accordion-heading-${props.itemId}`} data-parent={`#${props.accordionId}`}>
+            <div id={`collapse-${props.itemId}`} className={`collapse ${props.open ? 'show' : ''}`} aria-labelledby={`accordion-heading-${props.itemId}`} data-parent={props.accordionId ? `#${props.accordionId}` : ''}>
                 <div className="card-body">
                     {props.children}
                 </div>

--- a/bilhetinhos/src/main/components/home/Home.jsx
+++ b/bilhetinhos/src/main/components/home/Home.jsx
@@ -26,7 +26,7 @@ export default class Home extends Component {
                         </div>
                         <div className="row">
                             <div className="col-md-4 offset-md-4">
-                                <a href="/user/login" className="btn btn-primary btn-block btn-lg"><Translate text="home-login-button" /></a>
+                                <a href="/noteboard" className="btn btn-primary btn-block btn-lg"><Translate text="home-login-button" /></a>
                             </div>
                         </div>
                     </div>

--- a/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/MateNoteboardObserver.jsx
+++ b/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/MateNoteboardObserver.jsx
@@ -28,12 +28,19 @@ export class MateNoteboardObserver extends Component {
         if (locationUrl.searchParams.has('uid')) {
             let mateUid = locationUrl.searchParams.get('uid')
             this.startMateNoteboardListener(mateUid)
-            let mateHasUser = await areMates(this.props.currentUserUid, mateUid)
-            let userHasMate = await areMates(mateUid, this.props.currentUserUid)
-            this.props.sendFriendshipInfoToParent({
-                pendingInvite: (userHasMate && !mateHasUser),
-                areMates: (mateHasUser && userHasMate)
-            })
+            if (mateUid !== this.props.currentUserUid) {
+                let mateHasUser = await areMates(this.props.currentUserUid, mateUid)
+                let userHasMate = await areMates(mateUid, this.props.currentUserUid)
+                this.props.sendFriendshipInfoToParent({
+                    pendingInvite: (userHasMate && !mateHasUser),
+                    areMates: (mateHasUser && userHasMate)
+                })
+            } else {
+                this.props.sendFriendshipInfoToParent({
+                    pendingInvite: false,
+                    areMates: true
+                })
+            }
         }
 
         window.onbeforeunload = () => {

--- a/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/UserPresentation.jsx
+++ b/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/UserPresentation.jsx
@@ -16,7 +16,7 @@ const UserPresentation = props => {
                         <div className="col col-sm-3">
                             <div className="row">
                                 <div className="col">
-                                    <img src={`${props.profilePic || "/img/default_user_profile.png"}`} className="matenoteboard-profile-pic bg-light border border-secondary" alt="User profile picture" style={{ position: 'absolute', top: '-70px' }} />
+                                    <img src={`${props.profilePic || "/img/default_user_profile.png"}`} className="matenoteboard-profile-pic bg-light border border-secondary" alt="User profile picture" style={{ position: 'absolute', top: '-70px', width: '180px', height: '180px' }} />
                                 </div>
                             </div>
                             <div className="row mt-5">

--- a/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/index.jsx
+++ b/bilhetinhos/src/main/components/notes/Noteboards/MateNoteboard/index.jsx
@@ -64,9 +64,12 @@ export class MateNoteboard extends Component {
     }
 
     componentDidMount = async () => {
-        await this.callGetUserBoardPrivacy()
-        let isUserAllowedByPrivacy = await this.checkIfUserIsAllowedByPrivacy()
-        this.setState({ ...this.state, isUserAllowedByPrivacy })
+        let url = new URL(window.location)
+        if (url.searchParams.has('uid')) {
+            await this.callGetUserBoardPrivacy()
+            let isUserAllowedByPrivacy = await this.checkIfUserIsAllowedByPrivacy()
+            this.setState({ ...this.state, isUserAllowedByPrivacy })
+        }
     }
 
     checkIfUserIsAllowedByPrivacy = async () => {

--- a/bilhetinhos/src/main/components/notes/Noteboards/UserNoteboard/index.jsx
+++ b/bilhetinhos/src/main/components/notes/Noteboards/UserNoteboard/index.jsx
@@ -24,6 +24,13 @@ class Noteboard extends Component {
 
   shouldOpenEditorForNewNote = () => window.location.search.includes('new=note')
 
+  generateShowAsVisitorLink = () => {
+    let url = new URL(window.location)
+    url.pathname = 'mates/noteboard'
+    url.searchParams.set('uid', this.props.uid)
+    return url
+  }
+
   render() {
     return (
       <Skeleton>
@@ -34,12 +41,14 @@ class Noteboard extends Component {
               <button type="button" className="btn btn-link text-decoration-none btn-lg" data-toggle="modal" data-target="#edit-note-modal">
                 <Translate text="noteboard-btn-new-note" />
               </button>
+              <a href={this.generateShowAsVisitorLink()} className="btn btn-lg btn-link text-decoration-none">
+                <Translate text="noteboard-btn-show-board-as-visitor" />
+              </a>
               <hr />
               <RemoveNote onClose={this.onModalClose} />
               <NoteboardContainer containerId="notes-accordion">
                 <NoteboardSection
                   sectionId="user-notes"
-                  containerId="notes-accordion"
                   sectionTitle={window.translate({ text: "noteboard-accordion-my-notes-label" })}
                   isLoading={this.props.isLoadingUserNotes}
                   notes={this.props.userNotes}

--- a/bilhetinhos/src/main/components/notes/Noteboards/UserNoteboard/index.jsx
+++ b/bilhetinhos/src/main/components/notes/Noteboards/UserNoteboard/index.jsx
@@ -42,7 +42,7 @@ class Noteboard extends Component {
                 <Translate text="noteboard-btn-new-note" />
               </button>
               <a href={this.generateShowAsVisitorLink()} className="btn btn-lg btn-link text-decoration-none">
-                <Translate text="noteboard-btn-show-board-as-visitor" />
+                <Translate text="noteboard-btn-show-as-visitor" />
               </a>
               <hr />
               <RemoveNote onClose={this.onModalClose} />

--- a/bilhetinhos/src/main/components/user/Login.jsx
+++ b/bilhetinhos/src/main/components/user/Login.jsx
@@ -51,7 +51,7 @@ class Login extends Component {
         firebase.database().ref('users').once('value').then(userSnapshot => {
             if (!userSnapshot.hasChild(authResult.user.uid)) {
                 this.registerUserAndSaveState(authResult).then(() => {
-                    window.location.pathname = redirectUrl
+                    window.location = this.generateSignInSuccessUrl()
                 })
             } else {
                 const userFromFirebase = userSnapshot.child(`${authResult.user.uid}`).val()
@@ -59,13 +59,20 @@ class Login extends Component {
                 try {
                     firebase.storage().ref(userFromFirebase.profilePic).getDownloadURL().then(imageUrl => {
                         this.props.changePictureDownloadUrl(imageUrl)
-                        window.location = redirectUrl
+                        window.location = this.generateSignInSuccessUrl()
                     })
                 } catch (err) {
-                    window.location = redirectUrl
+                    window.location = this.generateSignInSuccessUrl()
                 }
             }
         })
+    }
+
+    generateSignInSuccessUrl = () => {
+        let url = new URL(window.location)
+        url.search = ''
+        url.pathname = '/noteboard'
+        return url
     }
 
     initializeFirebaseUi = () => {

--- a/bilhetinhos/src/main/translations/en/index.js
+++ b/bilhetinhos/src/main/translations/en/index.js
@@ -55,6 +55,7 @@ const en = {
   'noteboard-accordion-mates-notes-label': "Mates's notes",
   'noteboard-my-notes-no-note': "You haven't written any notes yet",
   'noteboard-mates-notes-no-note': 'Nothing to show here',
+  'noteboard-btn-show-as-visitor': 'View as visitor',
   'signout-label': 'Signing out...',
   'spinner-default-label': 'Loading...',
   'api-mates-added-successfully': 'User successfully added to your mates list',

--- a/bilhetinhos/src/main/translations/es/index.js
+++ b/bilhetinhos/src/main/translations/es/index.js
@@ -55,6 +55,7 @@ const es = {
     'noteboard-accordion-mates-notes-label': "Billetes de los colegas",
     'noteboard-my-notes-no-note': "Usted no ha escrito ningún billete",
     'noteboard-mates-notes-no-note': "Nada para mostrar aquí",
+    'noteboard-btn-show-as-visitor': 'Ver como visitante',
     'signout-label': "A salir...",
     'spinner-default-label': "Cargando...",
     'api-mates-added-successfully': "Usuario agregado a su lista de colegas con éxito.",

--- a/bilhetinhos/src/main/translations/pt/index.js
+++ b/bilhetinhos/src/main/translations/pt/index.js
@@ -55,6 +55,7 @@ const pt = {
     'noteboard-accordion-mates-notes-label': 'Bilhetes dos colegas',
     'noteboard-my-notes-no-note': 'Você ainda não escreveu nenhum bilhete',
     'noteboard-mates-notes-no-note': 'Nada para mostrar aqui',
+    'noteboard-btn-show-as-visitor': 'Ver como visitante',
     'signout-label': 'Saindo...',
     'spinner-default-label': 'Carregando...',
     'api-mates-added-successfully': 'Usuário adicionado à sua lista de colegas com sucesso.',

--- a/bilhetinhos/src/main/translations/translation.js
+++ b/bilhetinhos/src/main/translations/translation.js
@@ -284,6 +284,11 @@ export default {
     pt: pt['noteboard-mates-notes-no-note'],
     es: es['noteboard-mates-notes-no-note'],
   },
+  'noteboard-btn-show-as-visitor': {
+    en: en['noteboard-btn-show-as-visitor'],
+    pt: pt['noteboard-btn-show-as-visitor'],
+    es: es['noteboard-btn-show-as-visitor'],
+  },
   'signout-label': {
     en: en['signout-label'],
     pt: pt['signout-label'],


### PR DESCRIPTION
- Habilidade de ver o próprio quadro como visitante
- Correções de bug
    - Crash que ocorria quando não fornecíamos um uid ao visualizar o quadro de um colega
    - Agora a imagem do perfil é quadrada (180px) para evitar deformações
    - Agora o usuário é redirecionado para a tela inicial ao limpar as notificações enquanto visualiza o quadro de um colega (temporário)